### PR TITLE
Update post model/controller to respond to limit param

### DIFF
--- a/server/controllers/post.controller.js
+++ b/server/controllers/post.controller.js
@@ -32,10 +32,18 @@ function get(req, res) {
  * @returns {Post[]}
  */
 function list(req, res, next) {
-  const { limit = 50, createdAtBefore = null,
-      createdAfter = null, type = null, tags = null, categories = null, search = null } = req.query;
+  const {
+    limit = null,
+    createdAtBefore = null,
+    createdAfter = null,
+    type = null,
+    tags = null,
+    categories = null,
+    search = null
+  } = req.query;
 
-  const query = { limit };
+  const query = { };
+  if (limit) query.limit = limit;
   if (createdAtBefore) query.createdAtBefore = createdAtBefore;
   if (createdAfter) query.createdAfter = createdAfter;
   if (type) query.type = type;

--- a/server/models/post.model.js
+++ b/server/models/post.model.js
@@ -18,6 +18,7 @@ const PostSchema = new mongoose.Schema({
   content: {
     rendered: String,
   },
+  date: { type: Date, default: Date.now }
 });
 
 /**
@@ -61,15 +62,15 @@ PostSchema.statics = {
    * @returns {Promise<Post[]>}
    */
   list({
-      limitOption = 10,
-      createdAtBefore = null,
-      user = null,
-      createdAfter = null,
-      type = null,
-      tags = [],
-      categories = [],
-      search = null } = {}) {
-
+    limit = 10,
+    createdAtBefore = null,
+    user = null,
+    createdAfter = null,
+    type = null,
+    tags = [],
+    categories = [],
+    search = null
+  } = {}) {
     const query = { };
     let posts;
     // @TODO use
@@ -86,7 +87,7 @@ PostSchema.statics = {
     if (categories.length > 0) query.categories = { $all: categories };
     if (search) query.$text = { $search: search };
 
-    const limit = parseInt(limitOption, 10);
+    const limitOption = parseInt(limit, 10);
 
     let sort = { date: dateDirection };
 
@@ -106,7 +107,7 @@ PostSchema.statics = {
 
     return this.find(query, 'content title date mp3 link score featuredImage upvoted downvoted tags categories')
       .sort(sort)
-      .limit(limit)
+      .limit(limitOption)
       .then((postsFound) => {
         posts = postsFound;
         // Flip direct back


### PR DESCRIPTION
* limit default applied in model only
* added `date` to `PostSchema` - should not affect loading from Wordpress
* updated `post.test.js` to test limit and `changeOnAfter` offset
* added `saveMongoArrayPromise` utility function to save array of mongo instances prior to running tests, could later be moved to separate `util.js` file for use by multiple tests