### PR TITLE
Added /tags/ endpoint

### DIFF
--- a/server/controllers/tag.controller.js
+++ b/server/controllers/tag.controller.js
@@ -1,0 +1,45 @@
+import Tag from '../models/tag.model';
+
+/**
+ * Load tag and append to req.
+ */
+function load(req, res, next, id) {
+  Tag.get(id)
+    .then((tag) => {
+      req.tag = tag; // eslint-disable-line no-param-reassign
+      return next();
+    })
+    .catch(e => next(e));
+}
+
+
+/**
+ * Get tag.
+ * @returns {Tag}
+ */
+function get(req, res) {
+  return res.json(req.tag);
+}
+
+/**
+ * Get tag list.
+ * @property {number} req.query.skip - Number of users to be skipped.
+ * @property {number} req.query.limit - Limit number of users to be returned.
+ * @returns {Tag[]}
+ */
+function list(req, res, next) {
+  const {
+    limit = null,
+    skip = null
+  } = req.query;
+
+  const query = { };
+  if (limit) query.limit = limit;
+  if (skip) query.skip = skip;
+
+  Tag.list(query)
+    .then(tags => res.json(tags))
+    .catch(e => next(e));
+}
+
+export default { load, get, list };

--- a/server/models/tag.model.js
+++ b/server/models/tag.model.js
@@ -1,0 +1,60 @@
+import Promise from 'bluebird';
+import mongoose from 'mongoose';
+import httpStatus from 'http-status';
+import APIError from '../helpers/APIError';
+
+/**
+ * Tag Schema
+ */
+const TagSchema = new mongoose.Schema({
+  id: Number,
+  count: Number,
+  description: String,
+  link: String,
+  name: String,
+  slug: String,
+  taxonomy: String,
+  meta: Array,
+  _links: Object
+});
+
+/**
+ * Statics
+ */
+TagSchema.statics = {
+  /**
+   * Get tag
+   * @param {ObjectId} id - The objectId of user.
+   * @returns {Promise<Tag, APIError>}
+   */
+  get(id) {
+    return this.findOne({ id: id })
+      .exec()
+      .then((tag) => {
+        if (tag) {
+          return tag;
+        }
+        const err = new APIError('No such user exists!', httpStatus.NOT_FOUND);
+        return Promise.reject(err);
+      });
+  },
+
+  /**
+   * List tags
+   * @param {number} skip - Number of tags to be skipped.
+   * @param {number} limit - Limit number of tags to be returned.
+   * @returns {Promise<Post[]>}
+   */
+  list({skip = 0, limit = 50} = {}) {
+    return this.find({})
+      .sort({id: -1})
+      .skip(+skip)
+      .limit(+limit)
+      .exec();
+  }
+};
+
+/**
+ * @typedef Tag
+ */
+export default mongoose.model('Tag', TagSchema);

--- a/server/models/tag.model.js
+++ b/server/models/tag.model.js
@@ -34,7 +34,7 @@ TagSchema.statics = {
         if (tag) {
           return tag;
         }
-        const err = new APIError('No such user exists!', httpStatus.NOT_FOUND);
+        const err = new APIError('No such tag exists!', httpStatus.NOT_FOUND);
         return Promise.reject(err);
       });
   },

--- a/server/routes/index.route.js
+++ b/server/routes/index.route.js
@@ -4,6 +4,7 @@ import voteRoutes from './vote.route';
 import favoriteRoutes from './favorite.route';
 import authRoutes from './auth.route';
 import listenedRoutes from './listened.route';
+import tagsRoutes from './tag.route';
 
 // import userRoutes from './user.route';
 
@@ -17,6 +18,7 @@ router.use('/posts', postRoutes);
 router.use('/votes', voteRoutes);
 router.use('/favorites', favoriteRoutes);
 router.use('/listened', listenedRoutes);
+router.use('/tags', tagsRoutes);
 
 // mount user routes at /users
 // router.use('/users', userRoutes);

--- a/server/routes/tag.route.js
+++ b/server/routes/tag.route.js
@@ -1,0 +1,20 @@
+import express from 'express';
+import expressJwt from 'express-jwt';
+import tagCtrl from '../controllers/tag.controller';
+
+import config from '../../config/config';
+
+const router = express.Router(); // eslint-disable-line new-cap
+
+/** GET /api/tags/ - Get list of tags */
+router.route('/')
+  .get(expressJwt({secret: config.jwtSecret, credentialsRequired: false}), tagCtrl.list);
+
+/** GET /api/tags/:tagId - Get tag */
+router.route('/:tagId')
+  .get(tagCtrl.get);
+
+/** Load tag when API with tagId route parameter is hit */
+router.param('tagId', tagCtrl.load);
+
+export default router;

--- a/server/tests/tag.test.js
+++ b/server/tests/tag.test.js
@@ -1,4 +1,5 @@
 import mongoose from 'mongoose';
+import moment from 'moment';
 import request from 'supertest-as-promised';
 import httpStatus from 'http-status';
 import chai, {expect} from 'chai';
@@ -7,6 +8,12 @@ import Tag from '../models/tag.model';
 
 
 chai.config.includeStack = true;
+
+function saveMongoArrayPromise(model, dataArray) {
+  // this moved later into util file for use by multiple models and tests
+  return Promise.all(dataArray.map(data => model(data).save()));
+}
+
 
 /**
  * root level hooks
@@ -19,10 +26,12 @@ after((done) => {
   done();
 });
 
-xdescribe('## Tag APIs', () => {
+describe('## Tag APIs', () => {
   describe('# GET /api/tags/:tagId', () => {
     it('should get a tag details', (done) => {
-      const tag = new Tag();
+      const tag = new Tag({
+        'id': 2
+      });
       tag.save()
         .then((tagFound) => { //eslint-disable-line
           return request(app)
@@ -37,7 +46,7 @@ xdescribe('## Tag APIs', () => {
 
     it('should report error with message - Not found, when tag does not exists', (done) => {
       request(app)
-        .get('/api/tags/56c787ccc67fc16ccc1a5e92')
+        .get('/api/tags/123123123')
         .expect(httpStatus.NOT_FOUND)
         .then((res) => {
           expect(res.body.message).to.equal('Not Found');

--- a/server/tests/tag.test.js
+++ b/server/tests/tag.test.js
@@ -1,0 +1,45 @@
+import mongoose from 'mongoose';
+import request from 'supertest-as-promised';
+import httpStatus from 'http-status';
+import chai, {expect} from 'chai';
+import app from '../../index';
+
+chai.config.includeStack = true;
+
+/**
+ * root level hooks
+ */
+after((done) => {
+  // required because https://github.com/Automattic/mongoose/issues/1251#issuecomment-65793092
+  mongoose.models = {};
+  mongoose.modelSchemas = {};
+  mongoose.connection.close();
+  done();
+});
+
+xdescribe('## Tag APIs', () => {
+
+  describe('# GET /api/users/:userId', () => {
+    it('should get user details', (done) => {
+      request(app)
+        .get('/api/tags/')
+        .expect(httpStatus.OK)
+        .then((res) => {
+          done();
+        })
+        .catch(done);
+    });
+
+    it('should report error with message - Not found, when tag does not exists', (done) => {
+      request(app)
+        .get('/api/tags/56c787ccc67fc16ccc1a5e92')
+        .expect(httpStatus.NOT_FOUND)
+        .then((res) => {
+          expect(res.body.message).to.equal('Not Found');
+          done();
+        })
+        .catch(done);
+    });
+  });
+
+});


### PR DESCRIPTION
Me and @TheHollidayInn had a long conversation on how search could be improved in the SEdaily apps. One possible way was to display a whole bunch of all the tags to the user and let them choose the tags they find interesting and return the posts that match the intersection of all these tags.

The current api does support filtering of tags https://github.com/SoftwareEngineeringDaily/software-engineering-daily-api/blob/master/server/models/post.model.js#L90

However, there was no endpoint in the API which showed the user/mobile developers all the tags in the system hence they were unable to list them onto the app.

I have added the `/api/tags` and `/api/tags/:tagId` endpoints. I've tested them on my system and am pasting screenshots from Postman as well. Feel free to pull in these changes and test them on your system before merging. 

`/api/tags`
![](https://i.imgur.com/80kn0Dc.png)

`/api/tags/:tagId`
![](https://i.imgur.com/9TQ2Y8B.png)

cc @jasonify @crablar 