### PR TITLE
post.list returns bookmarked for user

### DIFF
--- a/server/models/post.model.js
+++ b/server/models/post.model.js
@@ -167,15 +167,13 @@ PostSchema.statics = {
       .sort(sort)
       .limit(limitOption);
 
+    // Flip direction back if originally limited by descending date filter
+    if (dateDirection === 1) {
+      queryPromise
+        .sort({ date: -1 });
+    }
     if (!user) {
-      return queryPromise.then((postsFound) => {
-        posts = postsFound;
-        // Flip direct back
-        if (dateDirection === 1) {
-          posts.reverse();
-        }
-        return postsFound;
-      });
+      return queryPromise.then(postsFound => postsFound);
     }
 
     return queryPromise
@@ -186,10 +184,6 @@ PostSchema.statics = {
       }).exec()
       .then((postsFound) => {
         posts = postsFound;
-        // Flip direct back
-        if (dateDirection === 1) {
-          posts.reverse();
-        }
         const postIds = posts.map((post) => { //eslint-disable-line
           return post._id;
         });
@@ -220,8 +214,7 @@ PostSchema.statics = {
           post.bookmarked = false;
           post.upvoted = false;
           post.downvoted = false;
-          // virtual is lost in toObject()
-          // even if the following set in schema: { toJSON: { virtuals: true } });
+          // note: virtuals not including in toObject by default
           const { favoritedByUser } = posts[index];
           if (favoritedByUser) post.bookmarked = favoritedByUser.active;
 


### PR DESCRIPTION
I used mongoose virtuals which provides the best of both worlds of MongoDB storage best practices of separate associative collection and ease-of-querying of embedded associative reference. 

I was also able to change minimally existing code, but this is something we may be want to consider to simplify join-like querying (see vote).

The property is exposed as `bookmarked` as this seems to be the direction for terminology we want to go for the project as a whole but left all other code the same ("favorite"). We may want to consider changing this soon in a separate PR for the (slight but real) benefit of overall team communication and decreased confusion for future contributors.

Resolves #83 