### PR TITLE
WIP: Decoupling comments from posts  to Prepare for Forum feature.

### DIFF
--- a/server/controllers/comment.controller.js
+++ b/server/controllers/comment.controller.js
@@ -97,14 +97,14 @@ function remove(req, res, next) {
  */
 
 function create(req, res, next) {
-  const { postId } = req.params;
+  const entityId = req.entity._id;
   const { parentCommentId } = req.body;
   const { content } = req.body;
   const { user } = req;
 
   const comment = new Comment();
   comment.content = content;
-  comment.post = postId;
+  comment.root = entityId;
   // If this is a child comment we need to assign it's parent
   if (parentCommentId) {
     comment.parentComment = parentCommentId;
@@ -142,9 +142,9 @@ function create(req, res, next) {
  *         $ref: '#/responses/NotFound'
  */
 function list(req, res, next) {
-  const { postId } = req.params;
+  const entityId = req.entity._id;
   // TODO loop through and replace comments that are deleted with "This comment has been deleted"
-  Comment.getTopLevelCommentsForItem(postId)
+  Comment.getTopLevelCommentsForItem(entityId)
     .then((comments) => {
       // Here we are fetching our nested comments, and need everything to finish
       const nestedCommentPromises = map(comments, comment => Comment.fillNestedComments(comment));

--- a/server/controllers/comment.controller.js
+++ b/server/controllers/comment.controller.js
@@ -104,7 +104,7 @@ function create(req, res, next) {
 
   const comment = new Comment();
   comment.content = content;
-  comment.root = entityId;
+  comment.rootEntity = entityId;
   // If this is a child comment we need to assign it's parent
   if (parentCommentId) {
     comment.parentComment = parentCommentId;

--- a/server/controllers/comment.controller.js
+++ b/server/controllers/comment.controller.js
@@ -97,7 +97,7 @@ function remove(req, res, next) {
  */
 
 function create(req, res, next) {
-  const entityId = req.entity._id;
+  const { entityId } = req.params;
   const { parentCommentId } = req.body;
   const { content } = req.body;
   const { user } = req;
@@ -142,7 +142,7 @@ function create(req, res, next) {
  *         $ref: '#/responses/NotFound'
  */
 function list(req, res, next) {
-  const entityId = req.entity._id;
+  const { entityId } = req.params;
   // TODO loop through and replace comments that are deleted with "This comment has been deleted"
   Comment.getTopLevelCommentsForItem(entityId)
     .then((comments) => {

--- a/server/controllers/forum.controller.js
+++ b/server/controllers/forum.controller.js
@@ -37,7 +37,7 @@ function create(req, res, next) {
   const { user } = req;
   forumThread.title = title;
   forumThread.content = content;
-  forumThread.authoer = user._id;
+  forumThread.author = user._id;
 
   forumThread
     .save()

--- a/server/controllers/forum.controller.js
+++ b/server/controllers/forum.controller.js
@@ -18,6 +18,9 @@ function detail() {
 function create() {
 }
 
+function update() {
+}
+
 function remove() {
 }
 
@@ -26,5 +29,6 @@ export default {
   list,
   detail,
   create,
+  update,
   remove
 };

--- a/server/controllers/forum.controller.js
+++ b/server/controllers/forum.controller.js
@@ -32,7 +32,8 @@ function list(req, res, next) {
     .catch(e => next(e));
 }
 
-function detail() {
+function detail(req, res) {
+  return res.json(req.forumThread);
 }
 
 function create(req, res, next) {

--- a/server/controllers/forum.controller.js
+++ b/server/controllers/forum.controller.js
@@ -10,6 +10,7 @@ function load(req, res, next, id) {
 }
 
 function list(req, res, next) {
+  /*
   const {
     limit = null,
     createdAtBefore = null,
@@ -22,9 +23,12 @@ function list(req, res, next) {
   if (createdAtBefore) query.createdAtBefore = createdAtBefore;
   if (createdAfter) query.createdAfter = createdAfter;
   if (search) query.search = search;
-
   ForumThread.list(query)
-    .then(posts => res.json(posts))
+    .then(threads => res.json(threads))
+    .catch(e => next(e));
+  */
+  ForumThread.list()
+    .then(threads => res.json(threads))
     .catch(e => next(e));
 }
 

--- a/server/controllers/forum.controller.js
+++ b/server/controllers/forum.controller.js
@@ -9,6 +9,22 @@ function load(req, res, next, id) {
     .catch(e => next(e));
 }
 
+
+function list() {
+}
+function detail() {
+}
+
+function create() {
+}
+
+function remove() {
+}
+
 export default {
-  load
+  load,
+  list,
+  detail,
+  create,
+  remove
 };

--- a/server/controllers/forum.controller.js
+++ b/server/controllers/forum.controller.js
@@ -1,0 +1,14 @@
+import ForumThread from '../models/forumThread.model';
+
+function load(req, res, next, id) {
+  ForumThread.get(id)
+    .then((forumThread) => {
+      req.forumThread = forumThread; // eslint-disable-line no-param-reassign
+      return next();
+    })
+    .catch(e => next(e));
+}
+
+export default {
+  load
+};

--- a/server/controllers/forum.controller.js
+++ b/server/controllers/forum.controller.js
@@ -33,6 +33,12 @@ function detail() {
 
 function create(req, res, next) {
   const forumThread = new ForumThread();
+  const { title, content, } = req.body;
+  const { user } = req;
+  forumThread.title = title;
+  forumThread.content = content;
+  forumThread.authoer = user._id;
+
   forumThread
     .save()
     .then((forumThreadSaved) => {

--- a/server/controllers/forum.controller.js
+++ b/server/controllers/forum.controller.js
@@ -9,13 +9,36 @@ function load(req, res, next, id) {
     .catch(e => next(e));
 }
 
+function list(req, res, next) {
+  const {
+    limit = null,
+    createdAtBefore = null,
+    createdAfter = null,
+    search = null
+  } = req.query;
 
-function list() {
+  const query = {};
+  if (limit) query.limit = Math.min(limit, 500);
+  if (createdAtBefore) query.createdAtBefore = createdAtBefore;
+  if (createdAfter) query.createdAfter = createdAfter;
+  if (search) query.search = search;
+
+  ForumThread.list(query)
+    .then(posts => res.json(posts))
+    .catch(e => next(e));
 }
+
 function detail() {
 }
 
-function create() {
+function create(req, res, next) {
+  const forumThread = new ForumThread();
+  forumThread
+    .save()
+    .then((forumThreadSaved) => {
+      res.status(201).json(forumThreadSaved);
+    })
+    .catch(err => next(err));
 }
 
 function update() {

--- a/server/controllers/forum.controller.js
+++ b/server/controllers/forum.controller.js
@@ -54,7 +54,24 @@ function create(req, res, next) {
 function update() {
 }
 
-function remove() {
+function remove(req, res, next) {
+  const { forumThread, user } = req;
+  if (forumThread && user) {
+    if (forumThread.author.toString() !== user._id.toString()) {
+      return res.status(401).json({ Error: 'Please login' });
+    }
+    forumThread.deleted = true;
+    return forumThread
+      .save()
+      .then(() => {
+        // Sucess:
+        res.json({ deleted: true });
+      })
+      .catch((e) => {
+        next(e);
+      });
+  }
+  return res.status(500).json({});
 }
 
 export default {

--- a/server/models/comment.model.js
+++ b/server/models/comment.model.js
@@ -56,7 +56,8 @@ const CommentSchema = new Schema({
   },
   author: {
     type: Schema.Types.ObjectId,
-    ref: 'User'
+    ref: 'User',
+    required: true
   }
 });
 

--- a/server/models/comment.model.js
+++ b/server/models/comment.model.js
@@ -25,7 +25,7 @@ import Vote from './vote.model';
  *         example: 2017-10-30T01:05:39.674Z
  *       author:
  *         $ref: '#/definitions/ObjectId'
- *       post:
+ *       root:
  *         $ref: '#/definitions/ObjectId'
  */
 const CommentSchema = new Schema({
@@ -50,15 +50,9 @@ const CommentSchema = new Schema({
   lastEdited: {
     type: Date
   },
-  /*
   root: {
     type: Schema.Types.ObjectId
     // , ref: 'Post' | 'AMA'
-  },
-  */
-  post: {
-    type: Schema.Types.ObjectId,
-    ref: 'Post'
   },
   author: {
     type: Schema.Types.ObjectId,
@@ -177,8 +171,8 @@ CommentSchema.statics = {
     return commentIds;
   },
 
-  getTopLevelCommentsForItem(postId) {
-    return this.find({ post: postId, parentComment: null })
+  getTopLevelCommentsForItem(entityId) {
+    return this.find({ root: entityId, parentComment: null })
       .sort({ dateCreated: -1 })
       .populate('author', '-password');
   },

--- a/server/models/comment.model.js
+++ b/server/models/comment.model.js
@@ -25,7 +25,7 @@ import Vote from './vote.model';
  *         example: 2017-10-30T01:05:39.674Z
  *       author:
  *         $ref: '#/definitions/ObjectId'
- *       root:
+ *       rootEntity:
  *         $ref: '#/definitions/ObjectId'
  */
 const CommentSchema = new Schema({
@@ -50,8 +50,8 @@ const CommentSchema = new Schema({
   lastEdited: {
     type: Date
   },
-  root: {
-    type: Schema.Types.ObjectId
+  rootEntity: {
+    type: Schema.Types.ObjectId // The entity that owns this comment
     // , ref: 'Post' | 'AMA'
   },
   author: {
@@ -105,7 +105,7 @@ CommentSchema.statics = {
   get(id) {
     return this.findById(id)
       .populate('author', '-password')
-      .populate('post')
+      // .populate('rootEntity')
       .exec()
       .then((comment) => {
         if (comment) {
@@ -173,7 +173,7 @@ CommentSchema.statics = {
   },
 
   getTopLevelCommentsForItem(entityId) {
-    return this.find({ root: entityId, parentComment: null })
+    return this.find({ rootEntity: entityId, parentComment: null })
       .sort({ dateCreated: -1 })
       .populate('author', '-password');
   },

--- a/server/models/forumThread.model.js
+++ b/server/models/forumThread.model.js
@@ -55,12 +55,14 @@ ForumThreadSchema.statics = {
       .then((threads) => {
         // Let's fill in the commentCount for each thread.
         // First we get the ids in an array:
-        const ids = map(threads, (thread) => {
-          console.log('ff');
+        const threadIds = map(threads, (thread) => {
+          // Get Thread ids
+          console.log('thread');
           return thread._id;
         });
-        console.log('---ids', ids);
+        console.log('threadIds', threadIds);
         return Comment.aggregate([
+          // { $match: { rootEntity: { $in: threadIds } } },
           { $group: { _id: '$rootEntity', count: { $sum: 1 } } }
         ])
           .then((result) => {

--- a/server/models/forumThread.model.js
+++ b/server/models/forumThread.model.js
@@ -25,7 +25,8 @@ const ForumThreadSchema = new mongoose.Schema({
     ref: 'User',
     required: true
   },
-  date: { type: Date, default: Date.now }
+  dateLastAcitiy: { type: Date, default: Date.now },
+  dateCreated: { type: Date, default: Date.now }
 });
 
 ForumThreadSchema.statics = {
@@ -61,7 +62,6 @@ ForumThreadSchema.statics = {
           console.log('thread');
           return thread._id;
         });
-        console.log('threadIds', threadIds);
         return Comment.aggregate([
           // Restrict to subset of threads (todo: paginate).
           { $match: { rootEntity: { $in: threadIds } } },
@@ -70,7 +70,6 @@ ForumThreadSchema.statics = {
           .then((counts) => {
             // TODO: loop and make commentCount = zero for all threads.
             // TODO: loop through threads and add counts:
-            console.log('-----------counts', counts);
             const expandedThreads = map(threads, (thread) => {
               const expandedThread = Object.assign({}, thread.toObject(), { commentCount: 0 });
               return expandedThread;
@@ -80,19 +79,15 @@ ForumThreadSchema.statics = {
             each(counts, (count) => {
               countsMap[count._id] = count.count;
             });
-            console.log('------------countsMap', countsMap);
 
             /* eslint-disable no-param-reassign */
             each(expandedThreads, (expandedThread) => {
               if (countsMap[expandedThread._id]) {
-                console.log('****************');
                 expandedThread.commentCount = countsMap[expandedThread._id];
-                console.log('new thread', expandedThread);
               }
             });
             /* eslint-enable no-param-reassign */
 
-            // return result;
             return expandedThreads;
           });
       });

--- a/server/models/forumThread.model.js
+++ b/server/models/forumThread.model.js
@@ -62,7 +62,7 @@ ForumThreadSchema.statics = {
         });
         console.log('threadIds', threadIds);
         return Comment.aggregate([
-          // { $match: { rootEntity: { $in: threadIds } } },
+          { $match: { rootEntity: { $in: threadIds } } },
           { $group: { _id: '$rootEntity', count: { $sum: 1 } } }
         ])
           .then((result) => {

--- a/server/models/forumThread.model.js
+++ b/server/models/forumThread.model.js
@@ -4,11 +4,11 @@ const ForumThreadSchema = new mongoose.Schema({
   id: String,
   score: { type: Number, default: 0 },
   title: {
-    rendered: String,
+    type: String,
     required: true
   },
   content: {
-    rendered: String,
+    type: String,
     required: true
   },
   date: { type: Date, default: Date.now }

--- a/server/models/forumThread.model.js
+++ b/server/models/forumThread.model.js
@@ -11,6 +11,10 @@ const ForumThreadSchema = new mongoose.Schema({
     type: String,
     required: true
   },
+  author: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User'
+  },
   date: { type: Date, default: Date.now }
 });
 

--- a/server/models/forumThread.model.js
+++ b/server/models/forumThread.model.js
@@ -33,6 +33,7 @@ ForumThreadSchema.statics = {
    */
   get(id) {
     return this.findById(id)
+      .populate('author', '-password')
       .exec()
       .then((thread) => {
         if (thread) {

--- a/server/models/forumThread.model.js
+++ b/server/models/forumThread.model.js
@@ -13,7 +13,8 @@ const ForumThreadSchema = new mongoose.Schema({
   },
   author: {
     type: mongoose.Schema.Types.ObjectId,
-    ref: 'User'
+    ref: 'User',
+    required: true
   },
   date: { type: Date, default: Date.now }
 });

--- a/server/models/forumThread.model.js
+++ b/server/models/forumThread.model.js
@@ -1,4 +1,6 @@
 import mongoose from 'mongoose';
+import httpStatus from 'http-status';
+import APIError from '../helpers/APIError';
 
 const ForumThreadSchema = new mongoose.Schema({
   id: String,
@@ -20,6 +22,22 @@ const ForumThreadSchema = new mongoose.Schema({
 });
 
 ForumThreadSchema.statics = {
+  /**
+   * Get post
+   * @param {ObjectId} id - The objectId of forum thread.
+   * @returns {Promise<Thread, APIError>}
+   */
+  get(id) {
+    return this.findById(id)
+      .exec()
+      .then((thread) => {
+        if (thread) {
+          return thread;
+        }
+        const err = new APIError('No such thread exists!', httpStatus.NOT_FOUND);
+        return Promise.reject(err);
+      });
+  },
   list() {
     return this.find()
       .exec();

--- a/server/models/forumThread.model.js
+++ b/server/models/forumThread.model.js
@@ -13,6 +13,10 @@ const ForumThreadSchema = new mongoose.Schema({
     type: String,
     required: true
   },
+  deleted: {
+    type: Boolean,
+    default: false
+  },
   author: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'User',
@@ -39,7 +43,9 @@ ForumThreadSchema.statics = {
       });
   },
   list() {
-    return this.find()
+    const query = {};
+    query.deleted = false;
+    return this.find(query)
       .exec();
   }
 };

--- a/server/models/forumThread.model.js
+++ b/server/models/forumThread.model.js
@@ -62,10 +62,13 @@ ForumThreadSchema.statics = {
         });
         console.log('threadIds', threadIds);
         return Comment.aggregate([
+          // Restrict to subset of threads (todo: paginate).
           { $match: { rootEntity: { $in: threadIds } } },
           { $group: { _id: '$rootEntity', count: { $sum: 1 } } }
         ])
           .then((result) => {
+            // TODO: loop and make commentCount = zero for all threads.
+            // TODO: loop through threads and add counts:
             console.log('-----------RESULT', result);
             // return result;
             return threads;

--- a/server/models/forumThread.model.js
+++ b/server/models/forumThread.model.js
@@ -1,0 +1,17 @@
+import mongoose from 'mongoose';
+
+const ForumThreadSchema = new mongoose.Schema({
+  id: String,
+  score: { type: Number, default: 0 },
+  title: {
+    rendered: String,
+    required: true
+  },
+  content: {
+    rendered: String,
+    required: true
+  },
+  date: { type: Date, default: Date.now }
+});
+
+export default mongoose.model('ForumThread', ForumThreadSchema);

--- a/server/models/forumThread.model.js
+++ b/server/models/forumThread.model.js
@@ -19,4 +19,11 @@ const ForumThreadSchema = new mongoose.Schema({
   date: { type: Date, default: Date.now }
 });
 
+ForumThreadSchema.statics = {
+  list() {
+    return this.find()
+      .exec();
+  }
+};
+
 export default mongoose.model('ForumThread', ForumThreadSchema);

--- a/server/models/forumThread.model.js
+++ b/server/models/forumThread.model.js
@@ -46,6 +46,7 @@ ForumThreadSchema.statics = {
     const query = {};
     query.deleted = false;
     return this.find(query)
+      .populate('author', '-password')
       .exec();
   }
 };

--- a/server/routes/comment.route.js
+++ b/server/routes/comment.route.js
@@ -1,12 +1,28 @@
 import express from 'express';
 import expressJwt from 'express-jwt';
+import validate from 'express-validation';
 import transferField from '../middleware/transferField';
+import paramValidation from '../../config/param-validation';
 import commentCtrl from '../controllers/comment.controller';
 import voteCtrl from '../controllers/vote.controller';
 import config from '../../config/config';
 
 const router = express.Router(); // eslint-disable-line new-cap
 
+
+router.route('/forEntity/:entityId')
+  .get(
+    expressJwt({
+      secret: config.jwtSecret,
+      credentialsRequired: false
+    }),
+    commentCtrl.list
+  )
+  .post(
+    expressJwt({ secret: config.jwtSecret })
+    , validate(paramValidation.comment)
+    , commentCtrl.create
+  );
 
 router.route('/:commentId/upvote')
   .post(

--- a/server/routes/forum.route.js
+++ b/server/routes/forum.route.js
@@ -1,7 +1,6 @@
 import express from 'express';
 import expressJwt from 'express-jwt';
 import forumCtrl from '../controllers/forum.controller';
-import commentCtrl from '../controllers/comment.controller';
 import transferField from '../middleware/transferField';
 import config from '../../config/config';
 import loadFullUser from '../middleware/loadFullUser.middleware';
@@ -43,23 +42,6 @@ router.route('/:forumThreadId/upvote')
     , voteCtrl.upvote // rename to upvoteHelper
     , voteCtrl.finish // IF we add a model.unlike we don't really need this..
   );
-
-router
-  .route('/:forumThreadId/comment')
-  .post(
-    expressJwt({ secret: config.jwtSecret, credentialsRequired: true }),
-    transferField({ source: 'forumThread', target: 'entity' }),
-    commentCtrl.create
-  );
-
-router
-  .route('/:forumThreadId/comments')
-  .get(
-    expressJwt({ secret: config.jwtSecret, credentialsRequired: false }),
-    transferField({ source: 'forumThread', target: 'entity' }),
-    commentCtrl.list
-  );
-
 router.param('forumThreadId', forumCtrl.load);
 
 export default router;

--- a/server/routes/forum.route.js
+++ b/server/routes/forum.route.js
@@ -1,0 +1,48 @@
+import express from 'express';
+import expressJwt from 'express-jwt';
+import forumCtrl from '../controllers/forum.controller';
+import commentCtrl from '../controllers/comment.controller';
+import transferField from '../middleware/transferField';
+import config from '../../config/config';
+import loadFullUser from '../middleware/loadFullUser.middleware';
+
+const router = express.Router(); // eslint-disable-line new-cap
+
+router.route('/')
+  .get(
+    expressJwt({ secret: config.jwtSecret, credentialsRequired: false })
+    , loadFullUser
+    , forumCtrl.list
+  );
+
+router
+  .route('/:forumThreadId')
+  .get(
+    expressJwt({ secret: config.jwtSecret, credentialsRequired: false }),
+    forumCtrl.detail
+  )
+  .put(expressJwt({ secret: config.jwtSecret, credentialsRequired: true }), forumCtrl.update)
+  .delete(
+    expressJwt({ secret: config.jwtSecret, credentialsRequired: true }),
+    forumCtrl.delete
+  );
+
+router
+  .route('/:forumThreadId/comment')
+  .post(
+    expressJwt({ secret: config.jwtSecret, credentialsRequired: true }),
+    transferField({ source: 'forumThread', target: 'entity' }),
+    commentCtrl.create
+  );
+
+router
+  .route('/:forumThreadId/comments')
+  .get(
+    expressJwt({ secret: config.jwtSecret, credentialsRequired: false }),
+    transferField({ source: 'forumThread', target: 'entity' }),
+    commentCtrl.list
+  );
+
+router.param('forumThreadId', forumCtrl.load);
+
+export default router;

--- a/server/routes/forum.route.js
+++ b/server/routes/forum.route.js
@@ -13,6 +13,11 @@ router.route('/')
     expressJwt({ secret: config.jwtSecret, credentialsRequired: false })
     , loadFullUser
     , forumCtrl.list
+  )
+  .post(
+    expressJwt({ secret: config.jwtSecret, credentialsRequired: true })
+    , loadFullUser
+    , forumCtrl.create
   );
 
 router

--- a/server/routes/forum.route.js
+++ b/server/routes/forum.route.js
@@ -24,7 +24,7 @@ router
   .put(expressJwt({ secret: config.jwtSecret, credentialsRequired: true }), forumCtrl.update)
   .delete(
     expressJwt({ secret: config.jwtSecret, credentialsRequired: true }),
-    forumCtrl.delete
+    forumCtrl.remove
   );
 
 router

--- a/server/routes/forum.route.js
+++ b/server/routes/forum.route.js
@@ -5,6 +5,7 @@ import commentCtrl from '../controllers/comment.controller';
 import transferField from '../middleware/transferField';
 import config from '../../config/config';
 import loadFullUser from '../middleware/loadFullUser.middleware';
+import voteCtrl from '../controllers/vote.controller';
 
 const router = express.Router(); // eslint-disable-line new-cap
 
@@ -30,6 +31,17 @@ router
   .delete(
     expressJwt({ secret: config.jwtSecret, credentialsRequired: true }),
     forumCtrl.remove
+  );
+
+router.route('/:forumThreadId/upvote')
+  .post(
+    expressJwt({ secret: config.jwtSecret })
+    // TODO: refactor to have these into one call like upvote: [method1, method2,...]
+    // upvoteHandlers
+    , transferField({ source: 'forumThread', target: 'entity' })
+    , voteCtrl.findVote
+    , voteCtrl.upvote // rename to upvoteHelper
+    , voteCtrl.finish // IF we add a model.unlike we don't really need this..
   );
 
 router

--- a/server/routes/index.route.js
+++ b/server/routes/index.route.js
@@ -11,6 +11,7 @@ import bookmarkRoutes from './bookmark.route';
 import authRoutes from './auth.route';
 import userRoutes from './user.route';
 import subscriptionRoutes from './subscription.route';
+import forumRoutes from './forum.route';
 import listenedRoutes from './listened.route';
 import tagsRoutes from './tag.route';
 // import userRoutes from './user.route';
@@ -42,6 +43,7 @@ router.get('/health-check', (req, res) =>
 router.use('/docs', docRoutes);
 router.use('/related-links', relatedLinkRoutes);
 router.use('/posts', postRoutes);
+router.use('/forum', forumRoutes);
 router.use('/jobs', jobRoutes);
 router.use('/companies', companyRoutes);
 router.use('/comments', commentRoutes);

--- a/server/routes/post.route.js
+++ b/server/routes/post.route.js
@@ -5,7 +5,6 @@ import paramValidation from '../../config/param-validation';
 import postCtrl from '../controllers/post.controller';
 import voteCtrl from '../controllers/vote.controller';
 import transferField from '../middleware/transferField';
-import commentCtrl from '../controllers/comment.controller';
 import relatedLinkCtrl from '../controllers/relatedLink.controller';
 import bookmarkCtrl from '../controllers/bookmark.controller';
 import listenedCtrl from '../controllers/listened.controller';
@@ -34,26 +33,6 @@ router.route('/:postId')
     , loadFullUser
     , postCtrl.get
   );
-
-router.route('/:postId/comments')
-  .get(
-    expressJwt({
-      secret: config.jwtSecret,
-      credentialsRequired: false
-    }),
-    transferField({ source: 'post', target: 'entity' }),
-    commentCtrl.list
-  );
-
-// Create a comment:
-router.route('/:postId/comment')
-  .post(
-    expressJwt({ secret: config.jwtSecret })
-    , validate(paramValidation.comment)
-    , transferField({ source: 'post', target: 'entity' })
-    , commentCtrl.create
-  );
-
 // Get related links associated with postId
 router.route('/:postId/related-links')
   .get(

--- a/server/routes/post.route.js
+++ b/server/routes/post.route.js
@@ -36,16 +36,21 @@ router.route('/:postId')
   );
 
 router.route('/:postId/comments')
-  .get(expressJwt({
-    secret: config.jwtSecret,
-    credentialsRequired: false
-  }), commentCtrl.list);
+  .get(
+    expressJwt({
+      secret: config.jwtSecret,
+      credentialsRequired: false
+    }),
+    transferField({ source: 'post', target: 'entity' }),
+    commentCtrl.list
+  );
 
 // Create a comment:
 router.route('/:postId/comment')
   .post(
     expressJwt({ secret: config.jwtSecret })
     , validate(paramValidation.comment)
+    , transferField({ source: 'post', target: 'entity' })
     , commentCtrl.create
   );
 

--- a/server/routes/post.route.js
+++ b/server/routes/post.route.js
@@ -74,8 +74,8 @@ router.route('/:postId/upvote')
     expressJwt({ secret: config.jwtSecret })
     , transferField({ source: 'post', target: 'entity' })
     , voteCtrl.findVote
-    , voteCtrl.upvote
-    , postCtrl.upvote
+    , voteCtrl.upvote // normal upvoting via vote model
+    , postCtrl.upvote // special-case: uses racoon upvoting just for posts.
     , voteCtrl.finish
   );
 

--- a/server/tests/comment.test.js
+++ b/server/tests/comment.test.js
@@ -80,7 +80,7 @@ describe('## Comment APIs', () => {
         .then((res) => {
           expect(res.body).to.exist; //eslint-disable-line
           const comment = res.body.result;
-          expect(comment.post).to.eql(`${postId}`);
+          expect(comment.root).to.eql(`${postId}`);
           expect(comment.content).to.eql(`${content}`);
           expect(comment.author).to.exist; //eslint-disable-line
           expect(comment.dateCreated).to.exist; //eslint-disable-line
@@ -116,7 +116,7 @@ describe('## Comment APIs', () => {
         .then((res) => {
           expect(res.body).to.exist; //eslint-disable-line
           const reply = res.body.result;
-          expect(reply.post).to.eql(`${postId}`);
+          expect(reply.root).to.eql(`${postId}`);
           expect(reply.content).to.eql(`${content}`);
           expect(reply.parentComment).to.eql(`${commentId}`);
           expect(reply.author).to.exist; //eslint-disable-line

--- a/server/tests/comment.test.js
+++ b/server/tests/comment.test.js
@@ -59,10 +59,10 @@ describe('## Comment APIs', () => {
       });
   });
 
-  describe('# POST /api/posts/$postId/comment', () => {
+  describe('# POST /api/comments/forEntity/$postId', () => {
     it('errors when not logged in', (done) => {
       request(app)
-        .post(`/api/posts/${postId}/comment`)
+        .post(`/api/comments/forEntity/${postId}`)
         .expect(httpStatus.UNAUTHORIZED)
         .then((res) => {
           expect(res.body).to.exist; //eslint-disable-line
@@ -73,7 +73,7 @@ describe('## Comment APIs', () => {
     it('comment on a post', (done) => {
       const content = 'Hello content!';
       request(app)
-        .post(`/api/posts/${postId}/comment`)
+        .post(`/api/comments/forEntity/${postId}`)
         .set('Authorization', `Bearer ${userToken}`)
         .send({ content })
         .expect(httpStatus.CREATED)
@@ -93,7 +93,7 @@ describe('## Comment APIs', () => {
 
     it('should get comments', (done) => {
       request(app)
-        .get(`/api/posts/${postId}/comments`)
+        .get(`/api/comments/forEntity/${postId}`)
         .expect(httpStatus.OK)
         .then((res) => {
           expect(res.body).to.exist; //eslint-disable-line
@@ -106,7 +106,7 @@ describe('## Comment APIs', () => {
     it('should reply a comment', (done) => {
       const content = 'Hello reply content!';
       request(app)
-        .post(`/api/posts/${postId}/comment`)
+        .post(`/api/comments/forEntity/${postId}`)
         .set('Authorization', `Bearer ${userToken}`)
         .send({
           content,

--- a/server/tests/comment.test.js
+++ b/server/tests/comment.test.js
@@ -116,7 +116,7 @@ describe('## Comment APIs', () => {
         .then((res) => {
           expect(res.body).to.exist; //eslint-disable-line
           const reply = res.body.result;
-          expect(reply.root).to.eql(`${postId}`);
+          expect(reply.rootEntity).to.eql(`${postId}`);
           expect(reply.content).to.eql(`${content}`);
           expect(reply.parentComment).to.eql(`${commentId}`);
           expect(reply.author).to.exist; //eslint-disable-line

--- a/server/tests/comment.test.js
+++ b/server/tests/comment.test.js
@@ -80,7 +80,7 @@ describe('## Comment APIs', () => {
         .then((res) => {
           expect(res.body).to.exist; //eslint-disable-line
           const comment = res.body.result;
-          expect(comment.root).to.eql(`${postId}`);
+          expect(comment.rootEntity).to.eql(`${postId}`);
           expect(comment.content).to.eql(`${content}`);
           expect(comment.author).to.exist; //eslint-disable-line
           expect(comment.dateCreated).to.exist; //eslint-disable-line


### PR DESCRIPTION
WIP

NOTES:

The comments refactor (inside the forum-v2 branch) could use some feedback. I wasn’t super happy with the way I refactored and was a bit conflicted about the way I am doing it now i.e rest endpoints are all on the comments route now but they are a little ugly  (vs having posts and ‘forum’ have their own /comment routes).

Also this way of doing it makes it a bit more ugly if we ever want to cache the commentCount on the `rootEntity` model itself (like we do for votes/score in post model).