### PR TITLE
Revert "added MemberExpression to indent rules"

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,9 +5,6 @@
       2,
       {
         "SwitchCase": 1
-      },
-      {
-        "MemberExpression": "off"
       }
     ],
     "space-before-function-paren": [


### PR DESCRIPTION
Reverts SoftwareEngineeringDaily/software-engineering-daily-api#184

Sadly I am seeing some problems.

> 
> /Users/jasonbautista/playground/sed/software-engineering-daily-api/.eslintrc:
> 	Configuration for rule "indent" is invalid:
> 	Value "2,[object Object],[object Object]" should NOT have more than 2 items.
> 
> Error: /Users/jasonbautista/playground/sed/software-engineering-daily-api/.eslintrc:
> 	Configuration for rule "indent" is invalid:
> 	Value "2,[object Object],[object Object]" should NOT have more than 2 items.