### PR TITLE
Add forms for profile social accounts and about section

### DIFF
--- a/config/param-validation.js
+++ b/config/param-validation.js
@@ -7,9 +7,14 @@ export default {
       username: Joi.string().required(),
       name: Joi.string().required(),
       bio: Joi.string().allow(''),
+      about: Joi.string().allow(''),
+      github: Joi.string().allow(''),
+      linkedin: Joi.string().allow(''),
+      twitter: Joi.string().allow(''),
       website: Joi.string().allow(''),
       isAvatarSet: Joi.boolean().required(),
-      email: Joi.string().email().allow('')
+      email: Joi.string().email().allow(''),
+      publicEmail: Joi.string().email().allow('')
     },
     params: {
       userId: Joi.string().hex().required()

--- a/server/models/user.model.js
+++ b/server/models/user.model.js
@@ -34,7 +34,19 @@ const UserSchema = new mongoose.Schema({
   bio: {
     type: String
   },
+  about: {
+    type: String
+  },
   website: {
+    type: String
+  },
+  linkedin: {
+    type: String
+  },
+  twitter: {
+    type: String
+  },
+  github: {
     type: String
   },
   verified: {
@@ -46,6 +58,9 @@ const UserSchema = new mongoose.Schema({
     default: false
   },
   email: {
+    type: String
+  },
+  publicEmail: {
     type: String
   },
   facebook: {
@@ -147,7 +162,7 @@ UserSchema.statics = {
   isValidHash: function validPassword({ original, hash }) {
     return bcrypt.compareSync(original, hash);
   },
-  updatableFields: ['username', 'website', 'bio', 'name', 'email']
+  updatableFields: ['username', 'website', 'bio', 'publicEmail', 'twitter', 'github', 'linkedin', 'about', 'name', 'email']
 };
 
 /**


### PR DESCRIPTION
Apart of the [_profile page redesign_:](https://github.com/SoftwareEngineeringDaily/sedaily-front-end/pull/436)

**Ability for user to store the following data in the database**:
               1. Github, LinkedIn, and Twitter Accounts
               2. Public Email Account
               3. About summary of user