### PR TITLE
ensure Favorite.listBookmarkedForUser has defaults

### DIFF
--- a/server/models/favorite.model.js
+++ b/server/models/favorite.model.js
@@ -96,10 +96,11 @@ FavoriteSchema.statics = {
         const postIds = bookmarks.map(bookmark => bookmark.postId);
         return Post.find({ _id: { $in: postIds } }, Post.standardSelectForFind)
           .sort({ date: -1 })
-          .lean() // return as plain object
+          // .lean() // returns as plain object, but this will remove default values which is bad
           .exec();
       }).then((posts) => {
-        const postsWithVotes = Post.addVotesForUserToPosts(posts, userId);
+        const _posts = posts.map(post => post.toObject());
+        const postsWithVotes = Post.addVotesForUserToPosts(_posts, userId);
         return postsWithVotes.map(post => Object.assign({}, post, { bookmarked: true }));
       });
   }


### PR DESCRIPTION
Resolves #199 

This was my oversight with use of `lean()` in `Favorite.listBookmarkedForUser` which removed any defaults (such as score).

It was a bit tricky to test for as when using Mongoose, Post.save() will include the default score, but I did add one which should hopefully prevent any potential regression.