### PR TITLE
Use correct parameters for sending error events. Add ErrorType enum

### DIFF
--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -7,7 +7,7 @@ import APIError from '../helpers/APIError';
 import config from '../../config/config';
 import User from '../models/user.model';
 import { signS3 } from '../helpers/s3';
-import sendError from '../helpers/events.helper';
+import { sendError, ErrorType } from '../helpers/events.helper';
 
 const http = require('http'); // For mailchimp api call
 require('dotenv').config();
@@ -228,7 +228,8 @@ function register(req, res, next) {
         console.log(`mailchimp error: ${e}`);
         sendError({
           userName: username,
-          eventData: {
+          errorType: ErrorType.OTHER,
+          errorData: {
             message: e
           }
         });
@@ -243,7 +244,8 @@ function register(req, res, next) {
     console.log(`mailchimp error: ${e}`);
     sendError({
       userName: username,
-      eventData: {
+      errorType: ErrorType.OTHER,
+      errorData: {
         message: e
       }
     });

--- a/server/controllers/job.controller.js
+++ b/server/controllers/job.controller.js
@@ -4,7 +4,7 @@ import Job from '../models/job.model';
 import APIError from '../helpers/APIError';
 import sgMail from '../helpers/mail';
 import transform from '../helpers/job.helper';
-import sendError from '../helpers/events.helper';
+import { sendError, ErrorType } from '../helpers/events.helper';
 
 require('babel-polyfill');
 
@@ -236,7 +236,8 @@ export default {
     } catch (err) {
       sendError({
         userName: req.user._id,
-        eventData: {
+        errorType: ErrorType.OTHER,
+        errorData: {
           message: err.message
         }
       });

--- a/server/helpers/events.helper.js
+++ b/server/helpers/events.helper.js
@@ -1,13 +1,25 @@
 import axios from 'axios';
 import config from '../../config/config';
 
-export default function sendError({ userName, eventData }) {
+function sendError({ userName, errorData, errorType }) {
   return axios.post(`${config.eventStreamUrl}error`, {
     clientId: userName,
+    eventApiEnv: config.env === 'production' ? 'production' : 'test',
     deviceType: 'API',
+    errorType,
     errorTime: new Date().getTime(),
-    eventData
+    errorData
   })
     .then(response => response)
     .catch(error => error);
 }
+
+const ErrorType = {
+  AUTH: 'auth',
+  OTHER: 'other'
+};
+
+export default {
+  sendError,
+  ErrorType
+};


### PR DESCRIPTION
The event stream API has changed since this was first implemented. This complies with those changes.