### PR TITLE
Fix: rss explicit tag to: clean

### DIFF
--- a/server/crons/rssFeed.cron.js
+++ b/server/crons/rssFeed.cron.js
@@ -125,7 +125,7 @@ async function callback() {
         },
         guid: parseInt(post.id, 10).toString(36),
         pubDate: moment.utc(post.date_gmt).toDate(),
-        'itunes:explicit': false
+        'itunes:explicit': 'clean'
       }
     });
 
@@ -152,7 +152,7 @@ async function callback() {
         },
         guid: parseInt(post.id, 10).toString(36),
         pubDate: moment.utc(post.date_gmt).toDate(),
-        'itunes:explicit': false
+        'itunes:explicit': 'clean'
       }
     });
   });


### PR DESCRIPTION
It looks like `itunes:explict` tag was in a old format (`false` value). Changed to `clean`

